### PR TITLE
Undefined reference on 'a2'

### DIFF
--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -272,7 +272,7 @@ function ja_calculate()
 			}
 
 			
-			ja_log("Angle between " + ja_selected[0][1] + " and " + ja_selected[1][1] + " is " + a + "(" + a2 + ") and position for label should be at " + ha, 3);
+			ja_log("Angle between " + ja_selected[0][1] + " and " + ja_selected[1][1] + " is " + a + " and position for label should be at " + ha, 3);
 
 			//put the angle point
 			ja_features.push(new ja_OpenLayers.Feature.Vector(


### PR DESCRIPTION
This fixes an error I was getting - undefined reference on a2.  This meant the angle between two selected roads wasn't working, but the angles between other segments around a selected node did still work.
