### PR TITLE
CROSS-MATCH issues

### DIFF
--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -1072,9 +1072,17 @@ function run_ja() {
 			ja_log(street_n_element, 2);
 			return (street_in.secondary.some(function (street_in_secondary, index2, array2){
 				ja_log("CN2a: checking n.p: " + street_n_element.primary.name + " vs in.s: " + street_in_secondary.name, 2);
+
+				//wlodek76: CROSS-MATCH works when two compared segments contain at least one ALT NAME - when alt name is empty cross-match does not work
+				if (street_n_element.secondary.length == 0) return false;
+                
 				return street_n_element.primary.name == street_in_secondary.name;
 			}) || street_n_element.secondary.some(function (street_n_secondary, index2, array2) {
 				ja_log("CN2b: checking in.p: " + street_in.primary.name + " vs n.s: " + street_n_secondary.name, 2);
+				
+				//wlodek76: CROSS-MATCH works when two compared segments contain at least one ALT NAME - when alt name is empty cross-match does not work
+				if (street_in.secondary.length == 0) return false;
+
 				//wlodek76: missing return from checking primary name with alternate names
 				return street_in.primary.name == street_n_secondary.name;
 			}));


### PR DESCRIPTION
Fixing issues with CROSS-MATCH, based on real tests on the map:
CROSS-MATCH works when two compared segments contain at least one ALT NAME.
When alt name is empty cross-match does not work

https://www.waze.com/pl/editor/?env=row&lon=16.97401&lat=52.33652&layers=388&zoom=7&segments=278564224,278564327,278564255,278564374