### PR TITLE
CROSS-MATCH - complementary optimized check

### DIFF
--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -1066,6 +1066,10 @@ function run_ja() {
 		ja_log("CN: init", 2);
 		ja_log(street_in, 2);
 		ja_log(streets, 2);
+		
+		//FZ69617: complementary optimized check
+		if (street_in.secondary.length == 0) return false;
+		
 		return Object.getOwnPropertyNames(streets).some(function (street_n_id, index, array) {
 			var street_n_element = streets[street_n_id];
 			ja_log("CN: Checking element " + index, 2);


### PR DESCRIPTION
Complementary check and good optimization suggested by FZ69617.
When street_in does not contain alt name do not iterate through other streets and do quick return.