### PR TITLE
New turns presentation

### DIFF
--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -45,7 +45,7 @@ function run_ja() {
 		ERROR: "junction_error",
 		ROUNDABOUT: "junction_roundabout"
 	};
-	
+
 	var ja_road_type = {
 		//Streets
 		STREET: 1,
@@ -67,7 +67,7 @@ function run_ja() {
 		RAILROAD: 18,
 		RUNWAY: 19
 	};
-	
+
 	var ja_vehicle_types = {
 		TRUCK: 1,
 		PUBLIC: 2,
@@ -142,7 +142,7 @@ function run_ja() {
 		style.appendChild(document.createTextNode(''
 				+ '#jaOptions label { display: inline; }\n'
 				+ '#jaOptions input, select { margin-right: 5px; }\n'
-			));
+		));
 
 		var form = document.createElement('form');
 		var section = document.createElement('div');
@@ -200,19 +200,19 @@ function run_ja() {
 			section.appendChild(ja_controls_container);
 		});
 		section.appendChild(document.createElement('br'));
-		
+
 		var ja_apply_button = document.createElement('button');
 		ja_apply_button.type = "button";
 		ja_apply_button.className = "btn btn-default";
 		ja_apply_button.addEventListener("click", ja_save, true);
 		ja_apply_button.appendChild(document.createTextNode(ja_getMessage("apply")));
-		
+
 		var ja_reset_button = document.createElement('button');
 		ja_reset_button.type = "button";
 		ja_reset_button.className = "btn btn-default";
 		ja_reset_button.addEventListener("click", ja_reset, true);
 		ja_reset_button.appendChild(document.createTextNode(ja_getMessage("resetToDefault")));
-		
+
 		section.appendChild(ja_apply_button);
 		section.appendChild(document.createTextNode(" "));
 		section.appendChild(ja_reset_button);
@@ -233,12 +233,12 @@ function run_ja() {
 
 		ja_settings_dom_panel.appendChild(ja_settings_dom_content);
 		ja_settings_dom.appendChild(ja_settings_dom_panel);
-		
+
 		//Add some version info etc
 		var ja_info = document.createElement('ul');
 		ja_info.className = "list-unstyled -side-panel-section";
 		ja_info.style.fontSize = "11px";
-		
+
 		var ja_version_elem = document.createElement('li');
 		ja_version_elem.appendChild(document.createTextNode(ja_getMessage("name") + ": v" + junctionangle_version));
 		ja_info.appendChild(ja_version_elem);
@@ -353,7 +353,7 @@ function run_ja() {
 		ja_log(street_in,2);
 
 		var angle = ja_angle_diff(s_in_a[0], (s_out_a[0]), false);
-		ja_log("Turn angle is: " + angle, 2);
+		ja_log("turn angle is: " + angle, 2);
 
 		//No other possible turns
 		if(node.attributes.segIDs.length <= 2) {
@@ -474,7 +474,7 @@ function run_ja() {
 
 			ja_log("No BC logic.............................", 2);
 
-			// Primary to non-primary
+			//Primary to non-primary
 			if(ja_is_primary_road(s_in) && !ja_is_primary_road(s_out[s_out_id])) {
 				ja_log("Primary to non-primary == exit", 2);
 				if(s_in.model.isLeftHand ? (angle > 0 ) : (angle < 0)) {
@@ -482,7 +482,7 @@ function run_ja() {
 				}
 			}
 
-			// Ramp to non-primary or non-ramp
+			//Ramp to non-primary or non-ramp
 			if(ja_is_ramp(s_in) && !ja_is_primary_road(s_out[s_out_id]) && !ja_is_ramp(s_out[s_out_id]) ) {
 				ja_log("Ramp to non-primary and non-ramp == exit", 2);
 				if(s_in.model.isLeftHand ? (angle > 0 ) : (angle < 0)) {
@@ -548,16 +548,16 @@ function run_ja() {
 
 		ja_nodes.forEach(function(node) {
 			ja_log(window.Waze.model.nodes.get(node), 3);
-			
+
 			var tmp_s = null;
 			var tmp_junctionID = null;
 			if(window.Waze.model.nodes.get(node) == null || typeof window.Waze.model.nodes.get(node).attributes.segIDs === 'undefined') return;
 			window.Waze.model.nodes.get(node).attributes.segIDs.forEach(function(segment) {
 				ja_log(segment, 3);
-				
+
 				if(window.Waze.model.segments.get(segment).attributes.junctionID) {
-						ja_log("WE ARE IN OR AROUND A ROUNDABOUT: " + window.Waze.model.segments.get(segment).attributes.junctionID, 3);
-						tmp_junctionID = window.Waze.model.segments.get(segment).attributes.junctionID;
+					ja_log("WE ARE IN OR AROUND A ROUNDABOUT: " + window.Waze.model.segments.get(segment).attributes.junctionID, 3);
+					tmp_junctionID = window.Waze.model.segments.get(segment).attributes.junctionID;
 				} else {
 					tmp_s = segment;
 					tmp_n = node;
@@ -599,7 +599,7 @@ function run_ja() {
 			ja_mapLayer.addFeatures([
 				new window.OpenLayers.Feature.Vector(
 					tmp_roundabout_center,
-					{ 
+					{
 						angle: ja_round(angle) + '°',
 						ja_type: ja_is_roundabout_normal(tmp_roundabout, ja_selected_roundabouts[tmp_roundabout].in_n) ? ja_routing_type.TURN : ja_routing_type.ROUNDABOUT
 					}
@@ -725,9 +725,9 @@ function run_ja() {
 				ha = (parseFloat(ja_selected_angles[0][0]) + parseFloat(ja_selected_angles[1][0]))/2;
 				if(
 					(Math.abs(ja_selected_angles[0][0]) + Math.abs(ja_selected_angles[1][0])) > 180
-				&& (
-						(ja_selected_angles[0][0] < 0 && ja_selected_angles[1][0] > 0)
-						|| (ja_selected_angles[0][0] > 0 && ja_selected_angles[1][0] < 0))
+					&& (
+					(ja_selected_angles[0][0] < 0 && ja_selected_angles[1][0] > 0)
+					|| (ja_selected_angles[0][0] > 0 && ja_selected_angles[1][0] < 0))
 					) ha += 180;
 
 				if (Math.abs(a) > 120) {
@@ -743,7 +743,7 @@ function run_ja() {
 
 				//Guess some routing instructions based on segment types, angles etc
 				var ja_junction_type = ja_routing_type.TURN; //Default to old behavior
-				
+
 				if(ja_getOption("guess")) {
 					ja_log(ja_selected_angles, 2);
 					ja_log(angles, 2);
@@ -856,9 +856,9 @@ function run_ja() {
 
 		var anglePoint = withRouting ?
 			new window.OpenLayers.Feature.Vector(
-			point
+				point
 				, { angle: (a>0?"<":"") + ja_round(Math.abs(a)) + "°" + (a<0?">":""), ja_type: ja_junction_type }
-		): new window.OpenLayers.Feature.Vector(
+			): new window.OpenLayers.Feature.Vector(
 			point
 			, { angle: ja_round(a) + "°", ja_type: "generic" }
 		);
@@ -1299,7 +1299,7 @@ function run_ja() {
 		ja_angle = Math.atan2(ja_dy, ja_dx);
 		return ((ja_angle * 180 / Math.PI)) % 360;
 	}
-	
+
 	/**
 	 * Decimal adjustment of a number. Borrowed (with some modifications) from
 	 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
@@ -1342,7 +1342,7 @@ function run_ja() {
 		if(!ja_options.hasOwnProperty(name) || typeof ja_options[name] === 'undefined') {
 			ja_options[name] = ja_settings[name]['defaultValue'];
 		}
-		
+
 		ja_log("Got value: " + ja_options[name], 2);
 		return ja_options[name];
 	}
@@ -1596,7 +1596,7 @@ function run_ja() {
 	function ja_getMessage(key) {
 		return I18n.translate('ja.' + key);
 	}
-	
+
 	function ja_loadTranslations() {
 		ja_log("Loading translations",2);
 		I18n.translations[window.I18n.defaultLocale].ja = {};
@@ -1674,7 +1674,7 @@ function run_ja() {
 		sv["rOverAlways"] = "Alltid";
 		sv["decimals"] = "Decimaler";
 		sv["pointSize"] = "Cirkelns basstorlek";
-		
+
 		//Apply
 		switch (I18n.locale) {
 			case 'sv':

--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -4,7 +4,7 @@
 // @description			Show the angle between two selected (and connected) segments
 // @include				/^https:\/\/(www|editor-beta)\.waze\.com\/(.{2,6}\/)?editor\/.*$/
 // @updateURL			https://github.com/milkboy/WME-ja/raw/master/wme_junctionangle.user.js
-// @version				1.8.4.2
+// @version				1.8.4.3
 // @grant				none
 // @copyright			2015 Michael Wikberg <waze@wikberg.fi>
 // @license				CC-BY-NC-SA
@@ -28,7 +28,7 @@ function run_ja() {
 	/*
 	 * First some variable and enumeration definitions
 	 */
-	var junctionangle_version = "1.8.4.2";
+	var junctionangle_version = "1.8.4.3";
 	var junctionangle_debug = 1;	//0: no output, 1: basic info, 2: debug 3: crazy debug
 	var $;
 
@@ -43,9 +43,12 @@ function run_ja() {
 		KEEP_RIGHT: "junction_keep_right",
 		TURN: "junction",
 		EXIT: "junction_exit",
+		EXIT_LEFT: "junction_exit_left",
+		EXIT_RIGHT: "junction_exit_right",
 		PROBLEM: "junction_problem",
 		ERROR: "junction_error",
-		ROUNDABOUT: "junction_roundabout"
+		ROUNDABOUT: "junction_roundabout",
+		ROUNDABOUT_EXIT: "junction_roundabout_exit",
 	};
 
 	var ja_road_type = {
@@ -370,7 +373,7 @@ function run_ja() {
 				return ja_routing_type.BC;
 			} else {
 				ja_log("Roundabout exit - no instruction", 2);
-				return ja_routing_type.EXIT;  //exit just to visually distinguish from roundabout continuation
+				return ja_routing_type.ROUNDABOUT_EXIT;  //exit just to visually distinguish from roundabout continuation
 			}
 		} else if (s_out[s_out_id].attributes.junctionID) {
 			ja_log("Roundabout entry - no instruction", 2);
@@ -404,8 +407,6 @@ function run_ja() {
 					|| (typeof s_n[a[1]] !== 'undefined'
 						&& ja_is_turn_allowed(s_in, node, s_n[a[1]])
 						&& Math.abs(ja_angle_diff(s_in_a, a[0], false)) <= 45
-						//&& Math.abs(ja_angle_diff(a[0], s_out_a[0], true)) > 1 //Arbitrarily chosen angle for "overlapping" segments.
-						//wlodek76: this part of code needs to be removed, it filters overlapped segments from angles which are used to take care about overlapped case !!!
 						)) {
 					ja_log(true, 4);
 					return true;
@@ -447,7 +448,7 @@ function run_ja() {
 				ja_log("BC candidates:", 2);
 				ja_log(bc_matches, 2);
 			};
-			
+
 			//wlodek76: variables for collecting most left angles
 			var mostleftangle  = null, templeftangle  = 0;
 			var mostleftangle2 = null, templeftangle2 = 0;
@@ -461,7 +462,7 @@ function run_ja() {
 
 				var tmp_angle = ja_angle_diff(s_in_a[0], a[0], false);
 				ja_log(tmp_angle, 2);
-				
+
 				//wlodek76: getting two most left angles
 				if (mostleftangle == null) {
 						mostleftangle = a;
@@ -507,6 +508,7 @@ function run_ja() {
 				}
 			}
 
+			//If s-out is the only BC, that's it.
 			if (bc_matches[s_out_id] !== undefined && bc_count == 1) {
 				ja_log("\"straight\": no instruction", 2);
 				return ja_routing_type.BC
@@ -514,39 +516,51 @@ function run_ja() {
 
 			ja_log("No BC logic.............................", 2);
 
+			//wlodek76: FIXING KEEP LEFT/RIGHT regarding to left most segment
+			//WIKI WAZE: When there are more than two segments less than 45.04°, only the left most segment will be KEEP LEFT, all the rest will be KEEP RIGHT
+			if (angles.length > 2) { //FZ69617: "more than two..."
+
+				//wlodek76: KEEP LEFT/RIGHT overlapping case
+				//WIKI WAZE: If the left most segment is overlapping another segment, it will also be KEEP RIGHT.
+				if (mostleftangle!=null && mostleftangle2!=null) {
+					var overlapped_angle = Math.abs(mostleftangle[0] - mostleftangle2[0]);
+
+					// If two top most left angles are close < 2 degree they are overlapped.
+					// Method of recognizing overlapped segment by server is unknown for me yet, I took this from WME Validator information about this.
+					// TODO: verify overlapping check on the side of routing server.
+					if (overlapped_angle < 2.0) {
+						mostleftangle = null;
+					}
+				}
+
+				if (mostleftangle != null && mostleftangle[1] == s_out_id) {
+					ja_log("Left most <45 segment: keep left", 2);
+					return ja_routing_type.KEEP_LEFT;
+				}
+			}
+
+			//FZ69617: Two overlapping sements logic
+			//WAZE WIKI: If the only two segments less than 45.04° overlap each other, neither will get an instruction.
+			if (angles.length == 2) {
+				var overlapped_angle = Math.abs(mostleftangle[0] - mostleftangle2[0]);
+
+				// TODO: verify overlapping check on the side of routing server.
+				if (overlapped_angle < 2.0) {
+					ja_log("Two overlapping sements: no instruction", 2);
+					return ja_routing_type.BC;  //PROBLEM?
+				}
+			}
+
 			//Primary to non-primary
 			if(ja_is_primary_road(s_in) && !ja_is_primary_road(s_out[s_out_id])) {
-				ja_log("Primary to non-primary == exit", 2);
-				if(s_in.model.isLeftHand ? (angle > 0 ) : (angle < 0)) {
-					return ja_routing_type.EXIT;
-				}
+				ja_log("Primary to non-primary = exit", 2);
+				return s_in.model.isLeftHand ? ja_routing_type.EXIT_LEFT : ja_routing_type.EXIT_RIGHT;
 			}
 
 			//Ramp to non-primary or non-ramp
 			if(ja_is_ramp(s_in) && !ja_is_primary_road(s_out[s_out_id]) && !ja_is_ramp(s_out[s_out_id]) ) {
-				ja_log("Ramp to non-primary and non-ramp == exit", 2);
-				if(s_in.model.isLeftHand ? (angle > 0 ) : (angle < 0)) {
-					return ja_routing_type.EXIT;
-				}
-			}
-			
-			//wlodek76: FIXING KEEP LEFT/RIGHT regarding to left most segment
-			//WIKI WAZE: When there are more than two segments less than 45.04°, only the left most segment will be KEEP LEFT, all the rest will be KEEP RIGHT
-			
-			//wlodek76: KEEP LEFT/RIGHT overlapping case
-			//WIKI WAZE: If the left most segment is overlapping another segment, it will also be KEEP RIGHT.
-			if (mostleftangle!=null && mostleftangle2!=null) {
-				var overlapped_angle = Math.abs(mostleftangle[0] - mostleftangle2[0]);
-				
-				// If two top most left angles are close < 2 degree they are overlapped.
-				// Method of recognizing overlapped segment by server is unknown for me yet, I took this from WME Validator information about this.
-				// TODO: verify overlapping check on the side of routing server.
-				if (overlapped_angle < 2.0) mostleftangle = null;
-			}
-			
-			if (mostleftangle != null && mostleftangle[1] == s_out_id) {
-				ja_log("DEFAULT: keep left", 2);
-				return ja_routing_type.KEEP_LEFT;
+				ja_log("Ramp to non-primary and non-ramp = exit", 2);
+				return s_in.model.isLeftHand ? ja_routing_type.EXIT_LEFT : ja_routing_type.EXIT_RIGHT;
 			}
 
 			ja_log("DEFAULT: keep right", 2);
@@ -830,7 +844,7 @@ function run_ja() {
 					a = (360 + (angles[(j + 1) % angles.length][0] - angle[0])) % 360;
 					ha = (360 + ((a / 2) + angle[0])) % 360;
 					var a_in = angles.filter(function(a,b,c) {
-						"use strict";
+						"use strict";
 						if(a[2]) return true;
 					})[0];
 
@@ -890,7 +904,7 @@ function run_ja() {
 	 * @param ja_junction_type If using routing, this needs to be set to the desired type
 	 */
 	function ja_draw_marker(point, node, ja_label_distance, a, ha, withRouting, ja_junction_type) {
-		"use strict";
+		"use strict";
 
 
 		//Try to estimate of the point is "too close" to another point (or maybe something else in the future; like turn restriction arrows or something)
@@ -914,13 +928,16 @@ function run_ja() {
 		}
 		ja_log("Done distance estimation", 3);
 
-		//wlodek76: drawing angle string '<' '>' accordingly to KEEP LEFT/RIGHT
-		var anglestring = (a>0?"<":"") + ja_round(Math.abs(a)) + "°" + (a<0?">":"");
-		if (ja_junction_type == ja_routing_type.KEEP_LEFT)  anglestring = "<" + ja_round(Math.abs(a)) + "°";
-		if (ja_junction_type == ja_routing_type.KEEP_RIGHT) anglestring =       ja_round(Math.abs(a)) + "°" + ">";
+		var anglestring = ja_round(Math.abs(a)) + "°";
 
-		//wlodek76: do not show left/right direction in best continuation we go only straight here
-		if (ja_junction_type == ja_routing_type.BC)         anglestring =       ja_round(Math.abs(a)) + "°";
+		//FZ69617: Show unicode direction arrows only for turn instructions
+		if (ja_junction_type == ja_routing_type.EXIT
+		    || ja_junction_type == ja_routing_type.KEEP)    anglestring = (a>0?"⇖\n":"⇗\n") + anglestring;
+		if (ja_junction_type == ja_routing_type.TURN)       anglestring = (a>0?"⇐\n":"⇒\n") + anglestring;
+		if (ja_junction_type == ja_routing_type.EXIT_LEFT)  anglestring = "⇖\n" + anglestring;
+		if (ja_junction_type == ja_routing_type.EXIT_RIGHT) anglestring = "⇗\n" + anglestring;
+		if (ja_junction_type == ja_routing_type.KEEP_LEFT)  anglestring = "⇖\n" + anglestring;
+		if (ja_junction_type == ja_routing_type.KEEP_RIGHT) anglestring = "⇗\n" + anglestring;
 
 		var anglePoint = withRouting ?
 			new window.OpenLayers.Feature.Vector(
@@ -1418,7 +1435,7 @@ function run_ja() {
 	}
 
 	var ja_onchange = function(e) {
-		"use strict";
+		"use strict";
 		switch(e.id) {
 			case ja_settings['guess'].elementId:
 				Object.getOwnPropertyNames(ja_settings).forEach(function (a,b,c) {
@@ -1623,12 +1640,16 @@ function run_ja() {
 				}),
 				ja_get_style_rule(ja_routing_type.TURN, "turnInstructionColor"),
 				ja_get_style_rule(ja_routing_type.BC, "noInstructionColor"),
+				ja_get_style_rule(ja_routing_type.KEEP,  "keepInstructionColor"),
 				ja_get_style_rule(ja_routing_type.KEEP_LEFT,  "keepInstructionColor"),
 				ja_get_style_rule(ja_routing_type.KEEP_RIGHT, "keepInstructionColor"),
 				ja_get_style_rule(ja_routing_type.EXIT, "exitInstructionColor"),
+				ja_get_style_rule(ja_routing_type.EXIT_LEFT, "exitInstructionColor"),
+				ja_get_style_rule(ja_routing_type.EXIT_RIGHT, "exitInstructionColor"),
 				ja_get_style_rule(ja_routing_type.PROBLEM, "problemColor"),
 				ja_get_style_rule(ja_routing_type.ERROR, "problemColor"),
 				ja_get_style_rule(ja_routing_type.ROUNDABOUT, "roundaboutColor"),
+				ja_get_style_rule(ja_routing_type.ROUNDABOUT_EXIT, "exitInstructionColor"),
 
 				new window.OpenLayers.Rule(
 					{

--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -518,7 +518,10 @@ function run_ja() {
 
 			//wlodek76: FIXING KEEP LEFT/RIGHT regarding to left most segment
 			//WIKI WAZE: When there are more than two segments less than 45.04°, only the left most segment will be KEEP LEFT, all the rest will be KEEP RIGHT
-			if (angles.length > 2) { //FZ69617: "more than two..."
+			if (true || angles.length > 2) { //FZ69617: "more than two..."
+						//FIXME: true added to temporarily ignore this condition
+						//without it many "keep left"s changed into "exit right"
+						//but I'm finally not sure whether we can safely ignore the precondition from Wiki?
 
 				//wlodek76: KEEP LEFT/RIGHT overlapping case
 				//WIKI WAZE: If the left most segment is overlapping another segment, it will also be KEEP RIGHT.
@@ -542,7 +545,7 @@ function run_ja() {
 			//FZ69617: Two overlapping sements logic
 			//WAZE WIKI: If the only two segments less than 45.04° overlap each other, neither will get an instruction.
 			if (angles.length == 2) {
-				var overlapped_angle = Math.abs(mostleftangle[0] - mostleftangle2[0]);
+				var overlapped_angle = Math.abs(angles[0][0] - angles[1][0]);
 
 				// TODO: verify overlapping check on the side of routing server.
 				if (overlapped_angle < 2.0) {

--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -4,7 +4,7 @@
 // @description			Show the angle between two selected (and connected) segments
 // @include				/^https:\/\/(www|editor-beta)\.waze\.com\/(.{2,6}\/)?editor\/.*$/
 // @updateURL			https://github.com/milkboy/WME-ja/raw/master/wme_junctionangle.user.js
-// @version				1.8.4
+// @version				1.8.4.1
 // @grant				none
 // @copyright			2015 Michael Wikberg <waze@wikberg.fi>
 // @license				CC-BY-NC-SA
@@ -28,7 +28,7 @@ function run_ja() {
 	/*
 	 * First some variable and enumeration definitions
 	 */
-	var junctionangle_version = "1.8.4";
+	var junctionangle_version = "1.8.4.1";
 	var junctionangle_debug = 1;	//0: no output, 1: basic info, 2: debug 3: crazy debug
 	var $;
 


### PR DESCRIPTION
Example of a new turns presentation:
![jaiv1 8 4 3-new-turns-presntation](https://cloud.githubusercontent.com/assets/6029380/7221352/2042fbfa-e6e8-11e4-85d2-9b211e0a4b4b.png)
Alike the best continuations, now also disallowed turns and the problems have no a maneuver arrows displayed.

Above picture was taken [here](https://www.waze.com/editor/?env=row&lon=15.49617&lat=51.93569&layers=1476&zoom=9&segments=213683496).
Please notice an "exit right" for which Livemap incorrectly suggests "keep right" - the client has "exit" in this case!

This change also adds logic for another 'Special consideration' from Wiki:
* If the only two segments less than 45.04° overlap each other, neither will get an instruction.

@milkboy and @wlodek76 please take a look at this change.