### PR TITLE
Three overlapping segments logic

### DIFF
--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -537,6 +537,13 @@ function run_ja() {
 				return ja_routing_type.BC;  //PROBLEM?
 			}
 
+			//wlodek76: Three overlapping segments logic
+			//MISSING IN WIKI: If the ONLY THREE segments less than 45.04° overlap each other, neither will get an instruction.
+			if (angles.length === 3 && ja_overlapping_angles(angles[0][0], angles[1][0]) && ja_overlapping_angles(angles[0][0], angles[2][0])) {
+				ja_log("Three overlapping segments: no instruction", 2);
+				return ja_routing_type.BC;  //PROBLEM?
+			}
+
 			//Primary to non-primary
 			if(ja_is_primary_road(s_in) && !ja_is_primary_road(s_out[s_out_id])) {
 				ja_log("Primary to non-primary = exit", 2);


### PR DESCRIPTION
Additional case, probably never will in real, but maybe it is worth to note it inside the code.
Based on real example: https://www.waze.com/pl/editor/?env=row&lon=16.97116&lat=52.33736&layers=1412&zoom=7&segments=278928679

![image](https://cloud.githubusercontent.com/assets/7284315/7339615/6e986bc2-ec75-11e4-8dae-55592b250d8f.png)

![image](https://cloud.githubusercontent.com/assets/7284315/7339617/8559e02a-ec75-11e4-9989-d477bac98627.png)
