### PR TITLE
Gray zone extended and U-turn instruction guessing fixed

### DIFF
--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -42,8 +42,8 @@ function run_ja() {
 	var ja_last_restart = 0, ja_roundabout_points = [], ja_options = {}, ja_mapLayer;
 
 	var TURN_ANGLE = 45.04;  //Turn vs. keep angle specified in Wiki.
-	var U_TURN_ANGLE = 168.24;  //U-Turn angle.
-	var GRAY_ZONE = 0.2;  //Gray zone angle based on irregularities observed on map.
+	var U_TURN_ANGLE = 168.24;  //U-Turn angle based on map experiments.
+	var GRAY_ZONE = 0.5;  //Gray zone angle intended to prevent from irregularities observed on map.
 	var OVERLAPPING_ANGLE = 0.666;  //Experimentally measured overlapping angle.
 
 	var ja_routing_type = {

--- a/wme_junctionangle.user.js
+++ b/wme_junctionangle.user.js
@@ -447,9 +447,18 @@ function run_ja() {
 			return ja_routing_type.BC;
 		}
 
+		//Check for U-turn, which is emitted even if there is only one s-out
+		if (Math.abs(angle) > U_TURN_ANGLE + GRAY_ZONE) {
+			ja_log("Angle is >= 170 - U-Turn", 2);
+			return ja_routing_type.U_TURN;
+		} else if (Math.abs(angle) > U_TURN_ANGLE - GRAY_ZONE) {
+			ja_log("Angle is in gray zone 169-171", 2);
+			return ja_routing_type.PROBLEM;
+		}
+
 		//No other possible turns
 		if(node.attributes.segIDs.length <= 2) {
-			ja_log("Only one possible turn", 2);
+			ja_log("Only one possible turn - no instruction", 2);
 			return ja_routing_type.BC;
 		} //No instruction
 
@@ -629,12 +638,6 @@ function run_ja() {
 			return s_in.model.isLeftHand ? ja_routing_type.KEEP_LEFT : ja_routing_type.KEEP_RIGHT;
 		} else if (Math.abs(angle) < TURN_ANGLE + GRAY_ZONE) {
 			ja_log("Angle is in gray zone 44-46", 2);
-			return ja_routing_type.PROBLEM;
-		} else if (Math.abs(angle) > U_TURN_ANGLE + GRAY_ZONE) {
-			ja_log("Angle is >= 170 = U-Turn", 2);
-			return ja_routing_type.U_TURN;
-		} else if (Math.abs(angle) > U_TURN_ANGLE - GRAY_ZONE) {
-			ja_log("Angle is in gray zone 169-171", 2);
 			return ja_routing_type.PROBLEM;
 		} else {
 			ja_log("Normal turn", 2);


### PR DESCRIPTION
Fixes for problems in the turn instruction estimation algorithm reported by [Arnoniem](https://www.waze.com/forum/memberlist.php?mode=viewprofile&u=13137498):
 *  ["turn left" instead of "u-turn"](https://www.waze.com/forum/viewtopic.php?f=819&t=61926&start=330#p1118556) - now it's in a gray zone,
 * [no "u-turn" instruction](https://www.waze.com/forum/viewtopic.php?f=819&t=61926&start=340#p1118559) - fixed.